### PR TITLE
Initial Fix for Log Files Issue

### DIFF
--- a/learning_observer/learning_observer/incoming_student_event.py
+++ b/learning_observer/learning_observer/incoming_student_event.py
@@ -423,12 +423,10 @@ async def incoming_websocket_handler(request):
         '''Prepare each event we receive for processing
         '''
         events = process_message_from_ws()
-        # NOTE: EVENT LOGS ARE USED HERE
         events = decoder_and_logger(events)
         events = decode_lock_fields(events)
         events = handle_auth_events(events)
         events = filter_blacklist_events(events)
-        # NOTE: STUDY LOGS ARE USED HERE
         events = pass_through_reducers(events)
         # empty loop to start the generator pipeline
         async for event in events:

--- a/learning_observer/learning_observer/log_event.py
+++ b/learning_observer/learning_observer/log_event.py
@@ -298,3 +298,7 @@ def log_ajax(url, resp_json, request):
     )
     with open(filename, "w") as ajax_log_fp:
         ajax_log_fp.write(encoded_payload)
+
+def close_logfile(filename):
+    # remove the file from the dict storing open log files and close it
+    files.pop(filename).close()

--- a/learning_observer/learning_observer/log_event.py
+++ b/learning_observer/learning_observer/log_event.py
@@ -304,5 +304,4 @@ def close_logfile(filename):
     old_file = files.pop(filename)
     if old_file is None:
         raise KeyError(f"Tried to remove log file {old_file} but it was not found")
-    else:
-        old_file.close()
+    old_file.close()

--- a/learning_observer/learning_observer/log_event.py
+++ b/learning_observer/learning_observer/log_event.py
@@ -301,4 +301,8 @@ def log_ajax(url, resp_json, request):
 
 def close_logfile(filename):
     # remove the file from the dict storing open log files and close it
-    files.pop(filename).close()
+    old_file = files.pop(filename)
+    if old_file is None:
+        raise KeyError(f"Tried to remove log file {old_file} but it was not found")
+    else:
+        old_file.close()


### PR DESCRIPTION
# Initial Fix

Created an initial fix for the log file issue that works locally. I added a function `close_logfile` that closes log files and removes them from the system's list of open log files. This function is called when the websocket connection associated with those log files is closed.

For the files ending in `.study.log` (which are created in `event_decoder_and_logger`, this fix works well, as the log closing mechanism is simply included in the same function where the filename is generated.

However, for the files just ending in `.log` (which are created in `handle_incoming_client_event`), it is not ideal because it requires returning a filename from that function and closing the log file outside of the function (the function `handle_incoming_client_event` cannot determine whether the events have stopped being received, and therefore does not know when to close the log file).

This is because while `event_decoder_and_logger` returns a function that handles an iterable of events, and we can simply close the log file once there are no events remaining (e.g. the socket is closed), `handle_incoming_client_event` returns a handler that is called each time an event is received. This means that if we implemented something similar to with `event_decoder_and_logger` in `handle_incoming_client_event`, the log file would be closed after every single event.

I tried refactoring `handle_incoming_client_event` to be more similar to `event_decoder_and_logger`, returning a function that handles many events, rather than just one event, but this would require changing the code structure significantly.

Note: this addresses issue [#106](https://github.com/ArgLab/ArgLab_writing_observer/issues/106) on the ArgLab fork of the repo.

