### PR TITLE
added startup info to an endpoint

### DIFF
--- a/learning_observer/learning_observer/log_event.py
+++ b/learning_observer/learning_observer/log_event.py
@@ -177,6 +177,11 @@ def initialize_logging_framework():
         # with larger files later. tar.gz should save a lot more
         sfp.write(startup_state)
 
+    # overwrite the current startup info for serving
+    current_startup_filename = "{directory}/startup.json".format(directory=paths.logs())
+    with open (current_startup_filename, 'w') as csfp:
+        csfp.write(startup_state)
+
 
 def encode_json_line(line):
     '''

--- a/learning_observer/learning_observer/log_event.py
+++ b/learning_observer/learning_observer/log_event.py
@@ -82,6 +82,7 @@ if not os.path.exists(paths.logs("startup")):
 
 mainlog = open(paths.logs("main_log.json"), "ab", 0)
 files = {}
+startup_state = learning_observer.filesystem_state.filesystem_state()
 
 
 # Do we make files for exceptions? Do we print extra stuff on the console?
@@ -164,8 +165,8 @@ def initialize_logging_framework():
     # This way, event logs can refer uniquely to running version
     # Do we want the full 512 bit hash? Cut it back? Use a more efficient encoding than
     # hexdigest?
-    startup_state = json.dumps(learning_observer.filesystem_state.filesystem_state(), indent=3, sort_keys=True)
-    STARTUP_STATE_HASH = learning_observer.util.secure_hash(startup_state.encode('utf-8'))
+    startup_state_dump = json.dumps(startup_state, indent=3, sort_keys=True)
+    STARTUP_STATE_HASH = learning_observer.util.secure_hash(startup_state_dump.encode('utf-8'))
     STARTUP_FILENAME = "{directory}/{time}-{hash}.json".format(
         directory=paths.logs("startup"),
         time=datetime.datetime.utcnow().isoformat(),
@@ -175,12 +176,7 @@ def initialize_logging_framework():
     with open(STARTUP_FILENAME, "w") as sfp:
         # gzip can save about 2-3x space. It makes more sense to do this
         # with larger files later. tar.gz should save a lot more
-        sfp.write(startup_state)
-
-    # overwrite the current startup info for serving
-    current_startup_filename = "{directory}/startup.json".format(directory=paths.logs())
-    with open (current_startup_filename, 'w') as csfp:
-        csfp.write(startup_state)
+        sfp.write(startup_state_dump)
 
 
 def encode_json_line(line):

--- a/learning_observer/learning_observer/routes.py
+++ b/learning_observer/learning_observer/routes.py
@@ -18,6 +18,7 @@ import learning_observer.admin as admin
 import learning_observer.auth
 import learning_observer.auth.http_basic
 import learning_observer.client_config
+import learning_observer.filesystem_state
 import learning_observer.impersonate
 import learning_observer.incoming_student_event as incoming_student_event
 import learning_observer.dashboard
@@ -28,7 +29,7 @@ import learning_observer.module_loader
 import learning_observer.paths as paths
 import learning_observer.settings as settings
 
-from learning_observer.log_event import debug_log
+from learning_observer.log_event import debug_log, startup_state
 
 from learning_observer.utility_handlers import *
 
@@ -103,7 +104,11 @@ def add_routes(app):
         ),
         aiohttp.web.get(
             '/startup-info',
-            static_file_handler(paths.logs('startup.json'))
+            learning_observer.auth.admin(json_response_handler(startup_state))
+        ),
+        aiohttp.web.get(
+            '/filesystem-state',
+            learning_observer.auth.admin(json_response_handler(learning_observer.filesystem_state.filesystem_state()))
         )
     ])
 

--- a/learning_observer/learning_observer/routes.py
+++ b/learning_observer/learning_observer/routes.py
@@ -101,6 +101,10 @@ def add_routes(app):
             '/config.json',
             learning_observer.client_config.client_config_handler
         ),
+        aiohttp.web.get(
+            '/startup-info',
+            static_file_handler(paths.logs('startup.json'))
+        )
     ])
 
     # We'd like to be able to have the root page themeable, for

--- a/learning_observer/learning_observer/utility_handlers.py
+++ b/learning_observer/learning_observer/utility_handlers.py
@@ -25,6 +25,14 @@ def static_file_handler(filename):
     return handler
 
 
+def json_response_handler(data):
+    '''Serve data (dict-like) as a json response
+    '''
+    async def handler(request):
+        return aiohttp.web.json_response(data)
+    return handler
+
+
 def redirect(new_path):
     '''
     Static, fixed redirect to a new location


### PR DESCRIPTION
Added startup info to a common file that is overwrritten when the system starts and the appropriate code to serve that file.

Should we lock this behind admin permissions?