### PR TITLE
WiP added action summary dashboard

### DIFF
--- a/modules/lo_action_summary/MANIFEST.in
+++ b/modules/lo_action_summary/MANIFEST.in
@@ -1,0 +1,1 @@
+include lo_action_summary/assets/*

--- a/modules/lo_action_summary/README.md
+++ b/modules/lo_action_summary/README.md
@@ -1,0 +1,3 @@
+# Learning Observer Action Summary
+
+This module allows users to view a student's history of events for a specific reducer context.

--- a/modules/lo_action_summary/lo_action_summary/assets/scripts.js
+++ b/modules/lo_action_summary/lo_action_summary/assets/scripts.js
@@ -1,0 +1,105 @@
+/**
+ * Javascript callbacks to be used with the LO Example dashboard
+ */
+
+// Initialize the `dash_clientside` object if it doesn't exist
+if (!window.dash_clientside) {
+  window.dash_clientside = {};
+}
+
+window.dash_clientside.lo_action_summary = {
+  /**
+   * Send updated queries to the communication protocol.
+   * @param {object} wsReadyState LOConnection status object
+   * @param {string} urlHash query string from hash for determining course id
+   * @returns stringified json object that is sent to the communication protocl
+   */
+  sendToLOConnection: async function (wsReadyState, urlHash) {
+    if (wsReadyState === undefined) {
+      return window.dash_clientside.no_update;
+    }
+    if (wsReadyState.readyState === 1) {
+      if (urlHash.length === 0) { return window.dash_clientside.no_update; }
+      const decodedParams = decode_string_dict(urlHash.slice(1));
+      if (!decodedParams.course_id) { return window.dash_clientside.no_update; }
+
+      if ('student_id' in decodedParams) {
+        decodedParams.student_id = [{ user_id: decodedParams.student_id }];
+      } else {
+        decodedParams.student_id = [];
+      }
+
+      const outgoingMessage = {
+        lo_action_summary_query: {
+          execution_dag: 'lo_action_summary',
+          target_exports: ['roster', 'action_summary'],
+          kwargs: decodedParams
+        }
+      };
+      return JSON.stringify(outgoingMessage);
+    }
+    return window.dash_clientside.no_update;
+  },
+
+  /**
+   * Process a message from LOConnection
+   * @param {object} incomingMessage object received from LOConnection
+   * @returns parsed data to local storage
+   */
+  receiveWSMessage: async function (incomingMessage) {
+    // TODO the naming here is broken serverside. Notice above we
+    //  called the target export `student_event_history_export`, i.e. the named
+    // export. Below, we need to call `lo_action_summary_join_roster`, i.e. the name
+    // of the node. This ought to be cleaned up in the communication protocl.
+    const parsedMessage = JSON.parse(incomingMessage.data);
+    const messageData = parsedMessage.lo_action_summary_query;
+    if (messageData.error !== undefined) {
+      console.error('Error received from server', messageData.error);
+      return {};
+    }
+    return messageData;
+  },
+
+  /**
+   * Build the student UI components based on the stored websocket data
+   * @param {*} wsStorageData information stored in the websocket store
+   * @returns Dash object to be displayed on page
+   */
+  populateStudentRadioItems: function (wsStorageData) {
+    if (!wsStorageData) {
+      return window.dash_clientside.no_update;
+    }
+    const roster = wsStorageData.roster || [];
+    let options = [];
+    for (const student of roster) {
+      const studentOption = {
+        value: student.user_id,
+        label: {
+          namespace: 'dash_html_components',
+          type: 'Div',
+          props: {
+            children: [{
+              namespace: 'lo_dash_react_components',
+              props: {
+                profile: student.profile,
+                className: 'student-name-tag d-inline-block',
+                includeName: true,
+                id: `${student.user_id}-activity-img`
+              },
+              type: 'LONameTag'
+            }]
+          }
+        }
+      };
+      options = options.concat(studentOption);
+    }
+    return options;
+  },
+
+  updateHashWithSelectedStudent: function (selected) {
+    if (selected == null) { return window.dash_clientside.no_update; }
+    const params = decode_string_dict(window.location.hash.slice(1));
+    return `#course_id=${params.course_id};student_id=${selected}`;
+  }
+
+};

--- a/modules/lo_action_summary/lo_action_summary/dash_dashboard.py
+++ b/modules/lo_action_summary/lo_action_summary/dash_dashboard.py
@@ -1,0 +1,96 @@
+'''
+'''
+from dash import html, dcc, callback, clientside_callback, ClientsideFunction, Output, Input
+import dash_bootstrap_components as dbc
+import lo_dash_react_components as lodrc
+
+
+_prefix = 'lo-action-summary'
+_namespace = 'lo_action_summary'
+_websocket = f'{_prefix}-websocket'
+_websocket_storage = f'{_prefix}-websocket-store'
+_student_list = f'{_prefix}-student-list'
+_student_output = f'{_prefix}-student-output'
+
+
+def layout():
+    '''
+    Function to define the page's layout.
+    '''
+    page_layout = html.Div(children=[
+        html.H1(children='Learning Observer Action Summary'),
+        dbc.InputGroup([
+            dbc.InputGroupText(lodrc.LOConnectionStatusAIO(aio_id=_websocket)),
+            lodrc.ProfileSidebarAIO(class_name='rounded-0 rounded-end', color='secondary'),
+        ]),
+        dcc.Store(id=_websocket_storage),
+        html.H2('Students'),
+        dbc.RadioItems(id=_student_list, inline=True),
+        html.H2('Action Summary'),
+        html.Div(id=_student_output)
+    ])
+    return page_layout
+
+# Send the initial state based on the url hash to LO.
+# If this is not included, nothing will be returned from
+# the communication protocol.
+clientside_callback(
+    ClientsideFunction(namespace=_namespace, function_name='sendToLOConnection'),
+    Output(lodrc.LOConnectionStatusAIO.ids.websocket(_websocket), 'send'),
+    Input(lodrc.LOConnectionStatusAIO.ids.websocket(_websocket), 'state'),  # used for initial setup
+    Input('_pages_location', 'hash')
+)
+
+# Handle receiving a message from the websocket.
+# This step will parse the message and update the
+# local storage accordingly.
+clientside_callback(
+    ClientsideFunction(namespace=_namespace, function_name='receiveWSMessage'),
+    Output(_websocket_storage, 'data'),
+    Input(lodrc.LOConnectionStatusAIO.ids.websocket(_websocket), 'message'),
+    prevent_initial_call=True
+)
+
+# Build the UI based on what we've received from the
+# communicaton protocol
+# This clientside callback and the serverside callback below are
+# the same
+clientside_callback(
+    ClientsideFunction(namespace=_namespace, function_name='populateStudentRadioItems'),
+    Output(_student_list, 'options'),
+    Input(_websocket_storage, 'data'),
+)
+
+clientside_callback(
+    ClientsideFunction(namespace=_namespace, function_name='updateHashWithSelectedStudent'),
+    Output('_pages_location', 'hash'),
+    Input(_student_list, 'value')
+)
+
+
+def create_markdown_text(events):
+    markdown_str = '```\n'
+    for e in events:
+        markdown_str += f'{e}\n'
+    markdown_str += '```'
+    return markdown_str
+
+
+@callback(
+    Output(_student_output, 'children'),
+    Input(_websocket_storage, 'data'),
+)
+def populate_output(data):
+    if not data:
+        return 'No student selected'
+    # there should only be 1
+    student_summaries = data.get('single_action_summary', [])
+    if len(student_summaries) == 0:
+        return 'No student selected'
+    
+    events = student_summaries[0]['events']
+    if len(events) > 0:
+        return html.Div([
+            dcc.Markdown(create_markdown_text(events))
+        ])
+    return 'No events found.'

--- a/modules/lo_action_summary/lo_action_summary/module.py
+++ b/modules/lo_action_summary/lo_action_summary/module.py
@@ -1,0 +1,90 @@
+'''
+Learning Observer Action Summary
+
+This module allows users to view a student's history of events for a specific reducer context.
+'''
+import learning_observer.downloads as d
+import learning_observer.communication_protocol.query as q
+from learning_observer.dash_integration import thirdparty_url, static_url
+from learning_observer.stream_analytics.helpers import KeyField, Scope
+
+import lo_action_summary.reducers
+import lo_action_summary.dash_dashboard
+
+# Name for the module
+NAME = 'Learning Observer Action Summary'
+
+course_roster = q.call('learning_observer.courseroster')
+
+EXECUTION_DAG = {
+    'execution_dag': {
+        'roster': course_roster(runtime=q.parameter('runtime'), course_id=q.parameter('course_id', required=True)),
+        'single_action_summary': q.select(q.keys('lo_action_summary.student_event_history', STUDENTS=q.parameter('student_id', required=True), STUDENTS_path='user_id'), fields=q.SelectFields.All),
+    },
+    'exports': {
+        'roster': {
+            'returns': 'roster',
+            'parameters': ['course_id'],
+        },
+        'action_summary': {
+            'returns': 'single_action_summary',
+            'parameters': ['course_id', 'student_id'],
+        }
+    }
+}
+
+# TODO we want the event history for both SBA and DA
+reducer_context = 'org.ets.sba'
+# reducer_context = 'org.ets.da'
+REDUCERS = [
+    {
+        'context': reducer_context,
+        'scope': Scope([KeyField.STUDENT]),
+        'function': lo_action_summary.reducers.student_event_history,
+        'default': {'events': []}
+    }
+]
+
+'''
+Define pages created with Dash.
+'''
+DASH_PAGES = [
+    {
+        'MODULE': lo_action_summary.dash_dashboard,
+        'LAYOUT': lo_action_summary.dash_dashboard.layout,
+        'ASSETS': 'assets',
+        'TITLE': 'Learning Observer Action Summary',
+        'DESCRIPTION': "This module allows users to view a student's history of events for a specific reducer context.",
+        'SUBPATH': 'lo-action-summary',
+        'CSS': [
+            thirdparty_url('css/fontawesome_all.css')
+        ],
+        'SCRIPTS': [
+            static_url('liblo.js')
+        ]
+    }
+]
+
+'''
+Additional files we want included that come from a third part.
+'''
+THIRD_PARTY = {
+    'css/fontawesome_all.css': d.FONTAWESOME_CSS,
+    'webfonts/fa-solid-900.woff2': d.FONTAWESOME_WOFF2,
+    'webfonts/fa-solid-900.ttf': d.FONTAWESOME_TTF
+}
+
+'''
+The Course Dashboards are used to populate the modules
+on the home screen.
+
+Note the icon uses Font Awesome v5
+'''
+COURSE_DASHBOARDS = [{
+    'name': NAME,
+    'url': '/lo_action_summary/dash/lo-action-summary',
+    'icon': {
+        'type': 'fas',
+        'icon': 'fa-play-circle'
+    }
+}]

--- a/modules/lo_action_summary/lo_action_summary/reducers.py
+++ b/modules/lo_action_summary/lo_action_summary/reducers.py
@@ -1,0 +1,14 @@
+from learning_observer.stream_analytics.helpers import student_event_reducer
+
+KEYS_TO_IGNORE = ['metadata', 'source', 'version', 'auth']
+
+
+@student_event_reducer(null_state={"events": []})
+async def student_event_history(event, internal_state):
+    '''
+    An example of a per-student event counter
+    '''
+    cleaned_event = {key: value for key, value in event['client'].items() if key not in KEYS_TO_IGNORE}
+    internal_state['events'].append(cleaned_event)
+
+    return internal_state, internal_state

--- a/modules/lo_action_summary/setup.cfg
+++ b/modules/lo_action_summary/setup.cfg
@@ -1,0 +1,10 @@
+[metadata]
+name = Learning Observer Action Summary
+description = Use this as a base template for creating new modules on the Learning Observer.
+
+[options]
+packages = lo_action_summary
+
+[options.entry_points]
+lo_modules =
+   lo_action_summary = lo_action_summary.module

--- a/modules/lo_action_summary/setup.py
+++ b/modules/lo_action_summary/setup.py
@@ -1,0 +1,14 @@
+'''
+Install script. Everything is handled in setup.cfg
+
+To set up locally for development, run `python setup.py develop`, in a
+virtualenv, preferably.
+'''
+from setuptools import setup
+
+setup(
+    name="lo_action_summary",
+    package_data={
+        'lo_action_summary': ['assets/*'],
+    }
+)


### PR DESCRIPTION
Added action summary dashboard with student select.

This provides a simple method of looking at the history of events from a given student for a specific reducer context (i.e. `org.ets.sba`). The dashboard currently displays a markdown rendering of each event (slightly parsed to remove some extraneous keys) on each line.