### PR TITLE
Pdeane reconstruct pr

### DIFF
--- a/modules/writing_observer/writing_observer/reconstruct_doc.py
+++ b/modules/writing_observer/writing_observer/reconstruct_doc.py
@@ -327,7 +327,7 @@ dispatch = {
                      #what text was NOT written by the author,
                      #logging the text buffer after the initial
                      #rplc action will give you that.
-    'rte': null, #suggestion
+    'rte' : null, #suggestion
     'rue': null, #suggestion
     'rvrt': replace, #apparently logged after an undo
     'sas': null, #suggestion. Autospell?

--- a/modules/writing_observer/writing_observer/reconstruct_doc.py
+++ b/modules/writing_observer/writing_observer/reconstruct_doc.py
@@ -9,22 +9,6 @@ See: `http://features.jsomers.net/how-i-reverse-engineered-google-docs/`
 
 import json
 
-"""
-The placeholder character is used to fill gaps in the document, particularly
-when there's a mismatch between the index and the length of the document's text (doc._text).
-In an empty document, the insertion index (from the insert event `is`) is 1. However,
-when the extension is started on a non-empty document, the first insertion index will be
-greater than 1. This can lead to inconsistencies in indexing. 
-This placeholder is used to fill the 'gap' between len(doc._text) and the first insertion 
-index recorded in the logs. 
-This is done for the delete event ('ds') as well.
-Say the first insert event in the logs is of a character 'a' with an index of 10 .
-This placeholder will be used to fill the gap between 1 and 10. Internally doc._text will
-have 10 characters and when returning the output, all placeholders will be removed from 
-doc._text leaving only the character 'a'.
-"""
-PLACEHOLDER = '\x00'
-
 
 class google_text(object):
     '''
@@ -161,12 +145,6 @@ class google_text(object):
             'edit_metadata': self._edit_metadata
         }
 
-    def get_parsed_text(self):
-        '''
-        Returns the text ignoring the normal placeholders
-        '''
-        return self._text.replace(PLACEHOLDER, "")
-
 
 def command_list(doc, commands):
     '''
@@ -201,13 +179,6 @@ def insert(doc, ty, ibi, s):
     * `ibi` is where the insert happens
     * `s` is the string to insert
     '''
-    # The index of the next character after the last character of the text
-    nextchar_index = len(doc._text) + 1
-    # If the insert index is greater than nextchar_index, insert placeholders to fill the gap
-    # This occurs when the document has undergone modifications before the logger has been initialized
-    if ibi > nextchar_index:
-        insert(doc, ty, nextchar_index, PLACEHOLDER * (ibi - nextchar_index))
-
     doc.update("{start}{insert}{end}".format(
         start=doc._text[0:ibi - 1],
         insert=s,
@@ -226,15 +197,6 @@ def delete(doc, ty, si, ei):
     * `si` is the index of the start of deletion
     * `ei` is the end
     '''
-    # Index of the last character in the text. `si` and `ei` shouldn't go beyond that
-    lastchar_index = len(doc._text)
-    # If the deletion indexes are greater than nextchar_index, insert placeholders to fill the gap
-    # This occurs when the document has undergone modifications before the logger has been initialized
-    if si > lastchar_index:
-        insert(doc, ty, lastchar_index + 1, PLACEHOLDER * (si - lastchar_index))
-    if ei > lastchar_index:
-        insert(doc, ty, lastchar_index + 1, PLACEHOLDER * (ei - lastchar_index))
-
     doc.update("{start}{end}".format(
         start=doc._text[0:si - 1],
         end=doc._text[ei:]
@@ -244,6 +206,41 @@ def delete(doc, ty, si, ei):
 
     return doc
 
+def replace(doc, ty, snapshot):
+    for entry in snapshot:
+
+        #The index of the next character after the last 
+        #character of the text
+        nextchar_index = len(doc._text) + 1
+        if 'ty' in entry and entry['ty'] == 'is':
+
+            s = entry['s']
+            ibi = entry['ibi']
+            if 'sl' in entry:
+                sl = entry['sl']
+            else:
+                sl = len(s)
+
+            #If the insert index is greater than
+            #nextchar_index, insert placeholders 
+            #to fill the gap.
+            #
+            # This occurs when the document has undergone
+            # modifications before the logger has been
+            # initialized
+            if ibi > nextchar_index:
+                insert(doc, 
+                       ty, 
+                       nextchar_index, 
+                       PLACEHOLDER * (ibi - nextchar_index))
+
+            doc.update("{start}{insert}{end}".format(
+                start=doc._text[0:ibi - 1],
+                insert=s,
+                end=doc._text[ibi + sl - 1:]
+            ))
+
+    return doc
 
 def alter(doc, si, ei, st, sm, ty):
     '''
@@ -271,17 +268,47 @@ def null(doc, **kwargs):
 # TODO: `ae,``ue,` `de,` and `te` need to be
 # reverse-engineered. These happens if we e.g. make a new bullet
 # list, or add an image.
+
+# TODO: 'iss' and 'dss' are generated when suggested text is inserted or deleted.
+# these can't be handled like plain 'is' or 'ds' because the include different fields
+# (e.g., 'sugid', presumably, suggestion id.)
 dispatch = {
     'ae': null,
+    'ase': null, #suggestion
+    'ast': null, #suggestion. Image?
+    'astss': null, #suggestion. Autospell?
     'ue': null,
     'de': null,
+    'dse': null, #suggestion
+    'dss': null, #suggested deletion
     'te': null,
     'as': alter,
     'ds': delete,
     'is': insert,
+    'iss': null, #suggested insertion
+    'mefd': null, #suggestion
     'mlti': multi,
+    'msfd': null, #suggestion
     'null': null,
+    'ord': null,
+    'ras': null, #suggestion. Autospell?
+    'rplc': replace, #rplc is called as the first edit
+                     #when the document is created from
+                     #a template, so if you want to know
+                     #what text was NOT written by the author,
+                     #logging the text buffer after the initial
+                     #rplc action will give you that.
+    'rte': null, #suggestion
+    'rue': null, #suggestion
+    'rvrt': replace, #apparently logged after an undo
+    'sas': null, #suggestion. Autospell?
     'sl': null,
+    'ste': null, #suggestion
+    'sue': null, #suggestion
+    'uefd': null, #suggestion
+    'use': null, #suggestion
+    'umv': null,
+    'usfd': null, #suggestion
 }
 
 if __name__ == '__main__':

--- a/modules/writing_observer/writing_observer/reconstruct_doc.py
+++ b/modules/writing_observer/writing_observer/reconstruct_doc.py
@@ -355,3 +355,4 @@ if __name__ == '__main__':
     print(doc)
     print(doc.position)
     print(doc.edit_metadata)
+

--- a/modules/writing_observer/writing_observer/reconstruct_doc.py
+++ b/modules/writing_observer/writing_observer/reconstruct_doc.py
@@ -2,7 +2,7 @@
 This can reconstruct a Google Doc from Google's JSON requests. It
 is based on the reverse-engineering by James Somers in his blog
 post about the Traceback extension. The code is, obviously, all
-new.
+new.r
 
 See: `http://features.jsomers.net/how-i-reverse-engineered-google-docs/`
 '''
@@ -48,7 +48,7 @@ class google_text(object):
         two lists for efficiency, and for now, this just confirms they're
         the same length.
         '''
-	        cursor_array_length = len(self._edit_metadata["cursor"])
+	cursor_array_length = len(self._edit_metadata["cursor"])
         textlength_array_length = len(self._edit_metadata["length"])
         length_difference = cursor_array_length - textlength_array_length
         if length_difference != 0:

--- a/modules/writing_observer/writing_observer/reconstruct_doc.py
+++ b/modules/writing_observer/writing_observer/reconstruct_doc.py
@@ -355,4 +355,3 @@ if __name__ == '__main__':
     print(doc)
     print(doc.position)
     print(doc.edit_metadata)
-

--- a/modules/writing_observer/writing_observer/reconstruct_doc.py
+++ b/modules/writing_observer/writing_observer/reconstruct_doc.py
@@ -354,4 +354,4 @@ if __name__ == '__main__':
     doc = command_list(doc, docs_history_short)
     print(doc)
     print(doc.position)
-	print(doc.edit_metadata)
+    print(doc.edit_metadata)

--- a/modules/writing_observer/writing_observer/reconstruct_doc.py
+++ b/modules/writing_observer/writing_observer/reconstruct_doc.py
@@ -200,6 +200,12 @@ def insert(doc, ty, ibi, s):
     * `ibi` is where the insert happens
     * `s` is the string to insert
     '''
+    # The index of the next character after the last character of the text
+    nextchar_index = len(doc._text) + 1
+    # If the insert index is greater than nextchar_index, insert placeholders to fill the gap
+    # This occurs when the document has undergone modifications before the logger has been initialized
+    if ibi > nextchar_index:
+        insert(doc, ty, nextchar_index, PLACEHOLDER * (ibi - nextchar_index))
     doc.update("{start}{insert}{end}".format(
         start=doc._text[0:ibi - 1],
         insert=s,

--- a/modules/writing_observer/writing_observer/reconstruct_doc.py
+++ b/modules/writing_observer/writing_observer/reconstruct_doc.py
@@ -354,4 +354,4 @@ if __name__ == '__main__':
     doc = command_list(doc, docs_history_short)
     print(doc)
     print(doc.position)
-    print(doc.edit_metadata)
+	print(doc.edit_metadata)

--- a/modules/writing_observer/writing_observer/reconstruct_doc.py
+++ b/modules/writing_observer/writing_observer/reconstruct_doc.py
@@ -2,7 +2,7 @@
 This can reconstruct a Google Doc from Google's JSON requests. It
 is based on the reverse-engineering by James Somers in his blog
 post about the Traceback extension. The code is, obviously, all
-new.r
+new.
 
 See: `http://features.jsomers.net/how-i-reverse-engineered-google-docs/`
 '''

--- a/modules/writing_observer/writing_observer/reconstruct_doc.py
+++ b/modules/writing_observer/writing_observer/reconstruct_doc.py
@@ -14,16 +14,17 @@ The placeholder character is used to fill gaps in the document, particularly
 when there's a mismatch between the index and the length of the document's text (doc._text).
 In an empty document, the insertion index (from the insert event `is`) is 1. However,
 when the extension is started on a non-empty document, the first insertion index will be
-greater than 1. This can lead to inconsistencies in indexing. 
-This placeholder is used to fill the 'gap' between len(doc._text) and the first insertion 
-index recorded in the logs. 
+greater than 1. This can lead to inconsistencies in indexing.
+This placeholder is used to fill the 'gap' between len(doc._text) and the first insertion
+index recorded in the logs.
 This is done for the delete event ('ds') as well.
-Say the first insert event in the logs is of a character 'a' with an index of 10 .
+Say the first insert event in the logs is of a character 'a' with an index of 10.
 This placeholder will be used to fill the gap between 1 and 10. Internally doc._text will
-have 10 characters and when returning the output, all placeholders will be removed from 
+have 10 characters and when returning the output, all placeholders will be removed from
 doc._text leaving only the character 'a'.
 """
 PLACEHOLDER = '\x00'
+
 
 class google_text(object):
     '''
@@ -48,7 +49,7 @@ class google_text(object):
         two lists for efficiency, and for now, this just confirms they're
         the same length.
         '''
-	cursor_array_length = len(self._edit_metadata["cursor"])
+        cursor_array_length = len(self._edit_metadata["cursor"])
         textlength_array_length = len(self._edit_metadata["length"])
         length_difference = cursor_array_length - textlength_array_length
         if length_difference != 0:
@@ -101,7 +102,6 @@ class google_text(object):
         new_object._edit_metadata = json_rep.get('edit_metadata', {})
         new_object.fix_validity()
         return new_object
-
 
     def update(self, text):
         '''
@@ -161,11 +161,13 @@ class google_text(object):
             'edit_metadata': self._edit_metadata
         }
 
+
 def get_parsed_text(self):
     '''
     Returns the text ignoring the normal placeholders
     '''
     return self._text.replace(PLACEHOLDER, "")
+
 
 def command_list(doc, commands):
     '''
@@ -224,7 +226,7 @@ def delete(doc, ty, si, ei):
     * `si` is the index of the start of deletion
     * `ei` is the end
     '''
-   # Index of the last character in the text. `si` and `ei` shouldn't go beyond that
+    # Index of the last character in the text. `si` and `ei` shouldn't go beyond that
     lastchar_index = len(doc._text)
     # If the deletion indexes are greater than nextchar_index, insert placeholders to fill the gap
     # This occurs when the document has undergone modifications before the logger has been initialized
@@ -241,11 +243,12 @@ def delete(doc, ty, si, ei):
 
     return doc
 
+
 def replace(doc, ty, snapshot):
     for entry in snapshot:
 
-        #The index of the next character after the last 
-        #character of the text
+        # The index of the next character after the last
+        # character of the text
         nextchar_index = len(doc._text) + 1
         if 'ty' in entry and entry['ty'] == 'is':
 
@@ -256,17 +259,17 @@ def replace(doc, ty, snapshot):
             else:
                 sl = len(s)
 
-            #If the insert index is greater than
-            #nextchar_index, insert placeholders 
-            #to fill the gap.
+            # If the insert index is greater than
+            # nextchar_index, insert placeholders
+            # to fill the gap.
             #
             # This occurs when the document has undergone
             # modifications before the logger has been
             # initialized
             if ibi > nextchar_index:
-                insert(doc, 
-                       ty, 
-                       nextchar_index, 
+                insert(doc,
+                       ty,
+                       nextchar_index,
                        PLACEHOLDER * (ibi - nextchar_index))
 
             doc.update("{start}{insert}{end}".format(
@@ -276,6 +279,7 @@ def replace(doc, ty, snapshot):
             ))
 
     return doc
+
 
 def alter(doc, si, ei, st, sm, ty):
     '''
@@ -309,41 +313,41 @@ def null(doc, **kwargs):
 # (e.g., 'sugid', presumably, suggestion id.)
 dispatch = {
     'ae': null,
-    'ase': null, #suggestion
-    'ast': null, #suggestion. Image?
-    'astss': null, #suggestion. Autospell?
+    'ase': null,  # suggestion
+    'ast': null,  # suggestion. Image?
+    'astss': null,  # suggestion. Autospell?
     'ue': null,
     'de': null,
-    'dse': null, #suggestion
-    'dss': null, #suggested deletion
+    'dse': null,  # suggestion
+    'dss': null,  # suggested deletion
     'te': null,
     'as': alter,
     'ds': delete,
     'is': insert,
-    'iss': null, #suggested insertion
-    'mefd': null, #suggestion
+    'iss': null,  # suggested insertion
+    'mefd': null,  # suggestion
     'mlti': multi,
-    'msfd': null, #suggestion
+    'msfd': null,  # suggestion
     'null': null,
     'ord': null,
-    'ras': null, #suggestion. Autospell?
-    'rplc': replace, #rplc is called as the first edit
-                     #when the document is created from
-                     #a template, so if you want to know
-                     #what text was NOT written by the author,
-                     #logging the text buffer after the initial
-                     #rplc action will give you that.
-    'rte' : null, #suggestion
-    'rue': null, #suggestion
-    'rvrt': replace, #apparently logged after an undo
-    'sas': null, #suggestion. Autospell?
+    'ras': null,  # suggestion. Autospell?
+    'rplc': replace,  # rplc is called as the first edit
+                      # when the document is created from
+                      # a template, so if you want to know
+                      # what text was NOT written by the author,
+                      # logging the text buffer after the initial
+                      # rplc action will give you that.
+    'rte': null,  # suggestion
+    'rue': null,  # suggestion
+    'rvrt': replace,  # apparently logged after an undo
+    'sas': null,  # suggestion. Autospell?
     'sl': null,
-    'ste': null, #suggestion
-    'sue': null, #suggestion
-    'uefd': null, #suggestion
-    'use': null, #suggestion
+    'ste': null,  # suggestion
+    'sue': null,  # suggestion
+    'uefd': null,  # suggestion
+    'use': null,  # suggestion
     'umv': null,
-    'usfd': null, #suggestion
+    'usfd': null,  # suggestion
 }
 
 if __name__ == '__main__':


### PR DESCRIPTION
 New PR for #201 so I can more easily make changes.
 
 > It turns out we were missing two critical commands 'rvrt' and 'rplc', both of which were used to replace large chunks of text, often the entire document. 'rplc' sometimes appears as the first command in a document, in which case it reflects the creation of a document from a template that the author didn't write. To handle this I wrote a replace() function to dispatch from 'rvrt' and 'rplc', plus null actions dispatched for a bunch of suggestion commands.

> In the course of getting this code ready to put a pull request in for, I seem to have created some whitespace differences I can't track down. They shouldn't matter, but sorry!

- Paul